### PR TITLE
Examples - EV calc

### DIFF
--- a/examples/sealed_ev.py
+++ b/examples/sealed_ev.py
@@ -1,0 +1,446 @@
+#!/usr/bin/env python3
+"""Sealed EV Calculator — Estimate booster pack expected value using MTGJSON data.
+
+Simulates opening N booster packs for a given set, prices every card pulled and reports expected value statistics.
+
+Usage:
+    python examples/sealed_ev.py MH3
+    python examples/sealed_ev.py MH3 --packs 500 --booster-type collector
+    python examples/sealed_ev.py DSK --provider tcgplayer --seed 42
+
+Requires: mtgjson-sdk (pip install mtgjson-sdk)
+"""
+
+from __future__ import annotations
+
+import argparse
+import random
+import statistics
+import sys
+import time
+from typing import Any
+
+from mtgjson_sdk import MtgjsonSDK
+
+# Log-scale bucket boundaries for the pack value histogram
+HISTOGRAM_BUCKETS = [0, 1, 2, 5, 10, 25, 50, 100]
+BAR_WIDTH = 40
+BAR_CHAR = "#"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Estimate booster pack expected value using MTGJSON data.",
+    )
+    parser.add_argument("set_code", help="Set code (e.g. MH3, DSK, BLB)")
+    parser.add_argument(
+        "--packs",
+        type=int,
+        default=1000,
+        help="Number of packs to simulate (default: 1000)",
+    )
+    parser.add_argument(
+        "--booster-type",
+        default="play",
+        help="Booster type (default: play)",
+    )
+    parser.add_argument(
+        "--provider",
+        default="tcgplayer",
+        help="Price provider (default: tcgplayer)",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Random seed for reproducibility",
+    )
+    return parser.parse_args()
+
+
+# ---------------------------------------------------------------------------
+# Data
+# ---------------------------------------------------------------------------
+
+PRICE_SQL = """\
+SELECT c.uuid, p.price
+FROM cards c
+JOIN all_prices_today p ON c.uuid = p.uuid
+WHERE c.setCode = $1
+  AND p.provider = $2
+  AND p.finish = $3
+  AND p.price_type = 'retail'
+  AND p.date = (SELECT MAX(p2.date) FROM all_prices_today p2)
+"""
+
+
+def fetch_price_maps(
+    sdk: MtgjsonSDK,
+    set_code: str,
+    provider: str,
+) -> tuple[dict[str, float], dict[str, float]]:
+    """Batch-fetch latest prices for all cards in a set.
+
+    Returns (normal_prices, foil_prices) dicts mapping uuid -> price.
+    Cards from foil booster sheets are priced using the foil map;
+    everything else uses the normal map.
+    """
+    # Warm up views so raw SQL works
+    _ = sdk.cards.count()
+    _ = sdk.prices.today("__warmup__")
+
+    normal = sdk.sql(PRICE_SQL, [set_code, provider, "normal"])
+    normal_map = {r["uuid"]: r["price"] for r in normal}
+
+    foil = sdk.sql(PRICE_SQL, [set_code, provider, "foil"])
+    foil_map = {r["uuid"]: r["price"] for r in foil}
+
+    return normal_map, foil_map
+
+
+# ---------------------------------------------------------------------------
+# Simulation
+# ---------------------------------------------------------------------------
+
+
+def simulate_packs(
+    sdk: MtgjsonSDK,
+    set_code: str,
+    booster_type: str,
+    n_packs: int,
+) -> list[list[dict[str, Any]]]:
+    packs: list[list[dict[str, Any]]] = []
+    for i in range(n_packs):
+        if i % 100 == 0:
+            print(f"\r  Simulating... {i}/{n_packs}", end="", flush=True)
+        pack = sdk.booster.open_pack(set_code, booster_type, as_dict=True)
+        packs.append(pack)
+    print(f"\r  Simulating... {n_packs}/{n_packs} done.     ")
+    return packs
+
+
+def price_card(
+    card: dict[str, Any],
+    normal_prices: dict[str, float],
+    foil_prices: dict[str, float],
+) -> float:
+    """Look up the price for a single card, respecting its foil status."""
+    uuid = card["uuid"]
+    is_foil = card.get("isFoil", False)
+
+    if is_foil:
+        # Prefer foil price, fall back to normal
+        return foil_prices.get(uuid, normal_prices.get(uuid, 0.0))
+    else:
+        # Prefer normal price, fall back to foil
+        return normal_prices.get(uuid, foil_prices.get(uuid, 0.0))
+
+
+def price_pack(
+    pack: list[dict[str, Any]],
+    normal_prices: dict[str, float],
+    foil_prices: dict[str, float],
+) -> float:
+    return round(sum(price_card(c, normal_prices, foil_prices) for c in pack), 2)
+
+
+# ---------------------------------------------------------------------------
+# Analysis
+# ---------------------------------------------------------------------------
+
+
+def compute_rarity_ev(
+    all_packs: list[list[dict[str, Any]]],
+    normal_prices: dict[str, float],
+    foil_prices: dict[str, float],
+    n_packs: int,
+) -> list[dict[str, Any]]:
+    """Average per-pack value contribution by rarity."""
+    totals: dict[str, float] = {}
+    counts: dict[str, int] = {}
+
+    for pack in all_packs:
+        for card in pack:
+            rarity = card.get("rarity", "unknown")
+            price = price_card(card, normal_prices, foil_prices)
+            totals[rarity] = totals.get(rarity, 0.0) + price
+            counts[rarity] = counts.get(rarity, 0) + 1
+
+    # Sort by value descending
+    result = []
+    for rarity in sorted(totals, key=lambda r: totals[r], reverse=True):
+        result.append(
+            {
+                "rarity": rarity,
+                "avg_per_pack": totals[rarity] / n_packs,
+                "total": totals[rarity],
+                "count": counts[rarity],
+            }
+        )
+    return result
+
+
+def compute_top_cards(
+    all_packs: list[list[dict[str, Any]]],
+    normal_prices: dict[str, float],
+    foil_prices: dict[str, float],
+    n_packs: int,
+    top_n: int = 10,
+) -> list[dict[str, Any]]:
+    """Top money cards by price, with pull rates."""
+    uuid_pulls: dict[str, int] = {}
+    uuid_info: dict[str, dict[str, Any]] = {}
+
+    for pack in all_packs:
+        for card in pack:
+            uuid = card["uuid"]
+            is_foil = card.get("isFoil", False)
+            # Track foil and non-foil pulls separately for accurate pricing
+            key = (uuid, is_foil)
+            uuid_pulls[key] = uuid_pulls.get(key, 0) + 1
+            if key not in uuid_info:
+                price = price_card(card, normal_prices, foil_prices)
+                uuid_info[key] = {
+                    "name": card["name"],
+                    "rarity": card.get("rarity", "?"),
+                    "price": price,
+                    "is_foil": is_foil,
+                }
+
+    ranked = sorted(uuid_info.items(), key=lambda x: x[1]["price"], reverse=True)
+
+    result = []
+    for key, info in ranked[:top_n]:
+        if info["price"] <= 0:
+            continue
+        pulls = uuid_pulls[key]
+        result.append(
+            {
+                "name": info["name"],
+                "rarity": info["rarity"],
+                "price": info["price"],
+                "is_foil": info["is_foil"],
+                "pulls": pulls,
+                "pull_rate_pct": pulls / n_packs * 100,
+            }
+        )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+
+def print_header(
+    set_name: str,
+    set_code: str,
+    booster_type: str,
+    provider: str,
+) -> None:
+    title = f"Sealed EV Calculator - {set_name} ({set_code})"
+    subtitle = f"Booster: {booster_type} | Provider: {provider}"
+    width = max(len(title), len(subtitle)) + 6
+    border = "=" * width
+    print()
+    print(f"  {border}")
+    print(f"  {title:^{width}}")
+    print(f"  {subtitle:^{width}}")
+    print(f"  {border}")
+
+
+def print_summary(
+    pack_values: list[float],
+    n_packs: int,
+    total_cards: int,
+    priced_count: int,
+    total_unique: int,
+) -> None:
+    mean = statistics.mean(pack_values)
+    median = statistics.median(pack_values)
+    stdev = statistics.stdev(pack_values) if len(pack_values) > 1 else 0.0
+    lo = min(pack_values)
+    hi = max(pack_values)
+
+    print()
+    print(f"  Simulated {n_packs:,} packs ({total_cards:,} cards)")
+    print(f"  Price coverage: {priced_count} / {total_unique} unique cards priced", end="")
+    if total_unique > 0:
+        print(f" ({priced_count / total_unique * 100:.1f}%)")
+    else:
+        print()
+
+    print()
+    print("  EXPECTED VALUE")
+    print("  " + "-" * 38)
+    print(f"  Mean:     ${mean:>7.2f}       Median:  ${median:.2f}")
+    print(f"  Std Dev:  ${stdev:>7.2f}")
+    print(f"  Min:      ${lo:>7.2f}       Max:     ${hi:.2f}")
+
+
+def print_rarity_breakdown(rarity_data: list[dict[str, Any]], mean_ev: float) -> None:
+    print()
+    print("  EV BY RARITY")
+    print("  " + "-" * 38)
+    print(f"  {'Rarity':<12s} {'Avg/Pack':>10s}  {'% of EV':>8s}")
+
+    for row in rarity_data:
+        avg = row["avg_per_pack"]
+        pct = (avg / mean_ev * 100) if mean_ev > 0 else 0
+        print(f"  {row['rarity']:<12s} ${avg:>8.2f}  {pct:>7.1f}%")
+
+
+def print_top_cards(top_cards: list[dict[str, Any]], n_packs: int) -> None:
+    print()
+    print("  TOP 10 MONEY CARDS")
+    print("  " + "-" * 38)
+    if not top_cards:
+        print("  (no priced cards found)")
+        return
+
+    # Find the longest name for alignment
+    max_name = max(len(c["name"]) for c in top_cards)
+    max_name = min(max_name, 28)  # cap width
+
+    print(f"  {'Card':<{max_name}s}  {'Price':>7s}  {'Pull %':>7s}")
+    for card in top_cards:
+        name = card["name"][:max_name]
+        foil_tag = " *" if card["is_foil"] else ""
+        print(
+            f"  {name:<{max_name}s}{foil_tag}  "
+            f"${card['price']:>6.2f}  "
+            f"{card['pull_rate_pct']:>6.1f}%"
+        )
+    # Legend for foil indicator
+    if any(c["is_foil"] for c in top_cards):
+        print("  (* = foil slot)")
+
+
+def print_histogram(pack_values: list[float]) -> None:
+    n = len(pack_values)
+    if n == 0:
+        return
+
+    # Count packs in each bucket
+    counts = [0] * len(HISTOGRAM_BUCKETS)
+    for v in pack_values:
+        placed = False
+        for i in range(len(HISTOGRAM_BUCKETS) - 1, 0, -1):
+            if v >= HISTOGRAM_BUCKETS[i]:
+                counts[i] += 1
+                placed = True
+                break
+        if not placed:
+            counts[0] += 1
+
+    max_count = max(counts) if counts else 1
+
+    print()
+    print("  PACK VALUE DISTRIBUTION")
+    print("  " + "-" * 38)
+
+    for i, count in enumerate(counts):
+        # Build label
+        if i < len(HISTOGRAM_BUCKETS) - 1:
+            label = f"${HISTOGRAM_BUCKETS[i]}-${HISTOGRAM_BUCKETS[i + 1]}"
+        else:
+            label = f"${HISTOGRAM_BUCKETS[i]}+"
+
+        bar_len = int(count / max_count * BAR_WIDTH) if max_count > 0 else 0
+        bar = BAR_CHAR * bar_len
+        pct = count / n * 100
+        print(f"  {label:>8s}  |{bar:<{BAR_WIDTH}s} {count:>5d} ({pct:5.1f}%)")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    args = parse_args()
+    set_code = args.set_code.upper()
+
+    if args.seed is not None:
+        random.seed(args.seed)
+
+    with MtgjsonSDK() as sdk:
+        # -- Validate set --
+        set_info = sdk.sets.get(set_code, as_dict=True)
+        if not set_info:
+            print(f"Error: Set '{set_code}' not found.")
+            sys.exit(1)
+
+        set_name = set_info.get("name", set_code)
+
+        # -- Validate booster type --
+        types = sdk.booster.available_types(set_code)
+        if not types:
+            print(f"Error: No booster data available for {set_name} ({set_code}).")
+            print("  This set may not have booster products, or the data")
+            print("  may not be available in the current MTGJSON build.")
+            sys.exit(1)
+
+        if args.booster_type not in types:
+            print(
+                f"Error: Booster type '{args.booster_type}' not available "
+                f"for {set_code}."
+            )
+            print(f"  Available types: {', '.join(types)}")
+            sys.exit(1)
+
+        # -- Fetch prices --
+        print(f"\n  Loading price data for {set_name}...")
+        normal_prices, foil_prices = fetch_price_maps(
+            sdk, set_code, args.provider
+        )
+
+        all_priced = set(normal_prices) | set(foil_prices)
+        if not all_priced:
+            print(
+                f"  Warning: No price data found for {set_code} "
+                f"(provider={args.provider}). All values will show $0.00."
+            )
+
+        # -- Simulate --
+        t0 = time.time()
+        all_packs = simulate_packs(sdk, set_code, args.booster_type, args.packs)
+        sim_time = time.time() - t0
+
+        # -- Price packs --
+        pack_values = [
+            price_pack(p, normal_prices, foil_prices) for p in all_packs
+        ]
+
+        # -- Stats --
+        total_cards = sum(len(p) for p in all_packs)
+        seen_uuids = {c["uuid"] for p in all_packs for c in p}
+        priced_count = len(seen_uuids & all_priced)
+
+        mean_ev = statistics.mean(pack_values)
+        rarity_data = compute_rarity_ev(
+            all_packs, normal_prices, foil_prices, args.packs
+        )
+        top_cards = compute_top_cards(
+            all_packs, normal_prices, foil_prices, args.packs
+        )
+
+        # -- Report --
+        print_header(set_name, set_code, args.booster_type, args.provider)
+        print_summary(pack_values, args.packs, total_cards, priced_count, len(seen_uuids))
+        print_rarity_breakdown(rarity_data, mean_ev)
+        print_top_cards(top_cards, args.packs)
+        print_histogram(pack_values)
+
+        print()
+        print(f"  Simulation completed in {sim_time:.1f}s")
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mtgjson_sdk/booster/simulator.py
+++ b/src/mtgjson_sdk/booster/simulator.py
@@ -3,18 +3,27 @@
 from __future__ import annotations
 
 import random
+from typing import Any
 
 from ..connection import Connection
 from ..models.cards import CardSet
 from ..models.submodels import BoosterConfig, BoosterPack, BoosterSheet
 
+# Views needed for flat booster tables (available from CDN)
+_BOOSTER_VIEWS = (
+    "set_booster_content_weights",
+    "set_booster_contents",
+    "set_booster_sheets",
+    "set_booster_sheet_cards",
+)
+
 
 class BoosterSimulator:
     """Simulates opening booster packs using set booster configuration data.
 
-    Uses weighted random selection based on the ``booster`` field in set
-    data (sheet weights and card weights). Requires the ``booster`` column
-    (present in AllPrintings, but NOT in the flat ``sets.parquet`` from CDN).
+    Uses weighted random selection based on official MTGJSON booster
+    configuration.  Loads data from flat booster parquet files (CDN) or
+    falls back to the nested ``booster`` column in AllPrintings.
 
     Example::
 
@@ -25,23 +34,132 @@ class BoosterSimulator:
 
     def __init__(self, conn: Connection) -> None:
         self._conn = conn
+        self._config_cache: dict[str, dict[str, BoosterConfig] | None] = {}
+        # Card data cache: (set_code, booster_type) -> {uuid: row_dict}
+        self._card_cache: dict[tuple[str, str], dict[str, dict[str, Any]]] = {}
 
-    def _ensure(self) -> None:
-        self._conn.ensure_views("sets", "cards")
+    def _ensure_booster_views(self) -> None:
+        self._conn.ensure_views(*_BOOSTER_VIEWS)
+
+    def _has_flat_views(self) -> bool:
+        return all(v in self._conn._registered_views for v in _BOOSTER_VIEWS)
 
     def _get_booster_config(self, set_code: str) -> dict[str, BoosterConfig] | None:
         """Get booster configuration for a set.
 
-        Requires the booster column (present in AllPrintings or test data,
-        but NOT in the flat sets.parquet from CDN).
+        Tries flat booster tables first, then falls
+        back to the nested booster column.
+        Results are cached per set code.
         """
-        self._ensure()
+        code = set_code.upper()
+        if code in self._config_cache:
+            return self._config_cache[code]
+
+        config = self._get_config_from_flat(code)
+        if not config:
+            config = self._get_config_from_nested(code)
+
+        self._config_cache[code] = config
+        return config
+
+    def _get_config_from_flat(self, set_code: str) -> dict[str, BoosterConfig] | None:
+        """Build booster config from the flat normalized parquet tables."""
+        self._ensure_booster_views()
+        if not self._has_flat_views():
+            return None
+
+        weights = self._conn.execute(
+            "SELECT boosterName, boosterIndex, boosterWeight "
+            "FROM set_booster_content_weights WHERE setCode = $1",
+            [set_code],
+        )
+        if not weights:
+            return None
+
+        contents = self._conn.execute(
+            "SELECT boosterName, boosterIndex, sheetName, sheetPicks "
+            "FROM set_booster_contents WHERE setCode = $1",
+            [set_code],
+        )
+        sheets_meta = self._conn.execute(
+            "SELECT boosterName, sheetName, sheetIsFoil, "
+            "sheetHasBalanceColors, sheetTotalWeight "
+            "FROM set_booster_sheets WHERE setCode = $1",
+            [set_code],
+        )
+        sheet_cards = self._conn.execute(
+            "SELECT boosterName, sheetName, cardUuid, cardWeight "
+            "FROM set_booster_sheet_cards WHERE setCode = $1",
+            [set_code],
+        )
+
+        # Reconstruct nested BoosterConfig from flat rows
+        result: dict[str, BoosterConfig] = {}
+        booster_names = {r["boosterName"] for r in weights}
+
+        for bname in sorted(booster_names):
+            # --- Pack templates ---
+            bw = [r for r in weights if r["boosterName"] == bname]
+            bc = [r for r in contents if r["boosterName"] == bname]
+
+            # Group sheet picks by booster index
+            idx_contents: dict[int, dict[str, int]] = {}
+            for r in bc:
+                idx_contents.setdefault(r["boosterIndex"], {})[r["sheetName"]] = (
+                    r["sheetPicks"]
+                )
+
+            boosters: list[BoosterPack] = []
+            total_weight = 0
+            for r in bw:
+                boosters.append(
+                    {
+                        "contents": idx_contents.get(r["boosterIndex"], {}),
+                        "weight": r["boosterWeight"],
+                    }
+                )
+                total_weight += r["boosterWeight"]
+
+            # --- Sheets ---
+            sm = [r for r in sheets_meta if r["boosterName"] == bname]
+            sc = [r for r in sheet_cards if r["boosterName"] == bname]
+
+            sheets: dict[str, BoosterSheet] = {}
+            for r in sm:
+                sname = r["sheetName"]
+                cards = {
+                    c["cardUuid"]: c["cardWeight"]
+                    for c in sc
+                    if c["sheetName"] == sname
+                }
+                sheet: BoosterSheet = {
+                    "cards": cards,
+                    "foil": r["sheetIsFoil"],
+                    "totalWeight": r["sheetTotalWeight"],
+                }
+                if r["sheetHasBalanceColors"]:
+                    sheet["balanceColors"] = True
+                sheets[sname] = sheet
+
+            result[bname] = {
+                "boosters": boosters,
+                "boostersTotalWeight": total_weight,
+                "sheets": sheets,
+                "sourceSetCodes": [set_code],
+            }
+
+        return result if result else None
+
+    def _get_config_from_nested(
+        self, set_code: str
+    ) -> dict[str, BoosterConfig] | None:
+        """Fall back to the nested booster column in AllPrintings / test data."""
+        self._conn.ensure_views("sets")
         try:
             rows = self._conn.execute(
-                "SELECT booster FROM sets WHERE code = $1", [set_code.upper()]
+                "SELECT booster FROM sets WHERE code = $1", [set_code]
             )
         except Exception:
-            # booster column may not exist in flat sets.parquet
             return None
         if not rows or not rows[0].get("booster"):
             return None
@@ -62,6 +180,37 @@ class BoosterSimulator:
             return []
         return list(config.keys())
 
+    def _ensure_card_cache(self, set_code: str, booster_type: str) -> None:
+        """Pre-fetch all cards that can appear in a booster type.
+
+        Collects every UUID across all sheets for the given booster type
+        and fetches their card data in a single DuckDB query.  Subsequent
+        ``open_pack`` calls resolve cards from this cache instead of
+        issuing per-pack queries.
+        """
+        key = (set_code.upper(), booster_type)
+        if key in self._card_cache:
+            return
+
+        config = self._get_booster_config(set_code)
+        if not config or booster_type not in config:
+            return
+
+        all_uuids: set[str] = set()
+        for sheet in config[booster_type]["sheets"].values():
+            all_uuids.update(sheet["cards"].keys())
+
+        if not all_uuids:
+            self._card_cache[key] = {}
+            return
+
+        self._conn.ensure_views("cards")
+        uuid_list = list(all_uuids)
+        placeholders = ", ".join(f"${i + 1}" for i in range(len(uuid_list)))
+        sql = f"SELECT * FROM cards WHERE uuid IN ({placeholders})"
+        rows = self._conn.execute(sql, uuid_list)
+        self._card_cache[key] = {r["uuid"]: r for r in rows}
+
     def open_pack(
         self,
         set_code: str,
@@ -70,6 +219,15 @@ class BoosterSimulator:
         as_dict: bool = False,
     ) -> list[CardSet] | list[dict]:
         """Simulate opening a single booster pack.
+
+        Each card in the returned list includes ``isFoil`` (whether the
+        card was pulled from a foil sheet) and ``boosterSheet`` (the
+        sheet name it came from).
+
+        On the first call for a given set/booster-type pair, all eligible
+        cards are pre-fetched in a single query.  Subsequent packs
+        resolve cards from the in-memory cache, making bulk simulation
+        (e.g. 1000+ packs) fast.
 
         Args:
             set_code: The set code (e.g., "MH3").
@@ -89,30 +247,36 @@ class BoosterSimulator:
                 f"Available: {list(configs.keys()) if configs else []}"
             )
 
+        # Pre-fetch card data on first call (single DuckDB query)
+        self._ensure_card_cache(set_code, booster_type)
+        card_data = self._card_cache.get((set_code.upper(), booster_type), {})
+
         config = configs[booster_type]
         pack_template = _pick_pack(config["boosters"])
         sheets = config["sheets"]
 
-        card_uuids: list[str] = []
+        # Track (uuid, sheet_name, is_foil) per pick so downstream
+        # code can distinguish foil vs non-foil slots.
+        picks: list[tuple[str, str, bool]] = []
         for sheet_name, count in pack_template["contents"].items():
             if sheet_name not in sheets:
                 continue
             sheet = sheets[sheet_name]
             picked = _pick_from_sheet(sheet, count)
-            card_uuids.extend(picked)
+            is_foil = sheet.get("foil", False)
+            picks.extend((uuid, sheet_name, is_foil) for uuid in picked)
 
-        if not card_uuids:
+        if not picks:
             return []
 
-        # Fetch card data
-        self._conn.ensure_views("cards")
-        placeholders = ", ".join(f"${i + 1}" for i in range(len(card_uuids)))
-        sql = f"SELECT * FROM cards WHERE uuid IN ({placeholders})"
-        rows = self._conn.execute(sql, card_uuids)
-
-        # Preserve pack order
-        uuid_to_row: dict[str, dict] = {r["uuid"]: r for r in rows}
-        ordered = [uuid_to_row[u] for u in card_uuids if u in uuid_to_row]
+        # Resolve cards from cache and inject sheet metadata
+        ordered = []
+        for uuid, sheet_name, is_foil in picks:
+            if uuid in card_data:
+                card = dict(card_data[uuid])
+                card["isFoil"] = is_foil
+                card["boosterSheet"] = sheet_name
+                ordered.append(card)
 
         if as_dict:
             return ordered

--- a/src/mtgjson_sdk/connection.py
+++ b/src/mtgjson_sdk/connection.py
@@ -136,10 +136,20 @@ class Connection:
         Introspects the parquet schema on first registration and builds
         the view SQL dynamically, so the SDK adapts to upstream schema
         changes without code updates.
+
+        If the backing file is not available (i.e. offline mode with no
+        cache), the view is silently skipped.  Downstream queries that
+        reference a missing view will receive empty results or None.
         """
         if view_name in self._registered_views:
             return
-        path = self.cache.ensure_parquet(view_name)
+        try:
+            path = self.cache.ensure_parquet(view_name)
+        except FileNotFoundError:
+            logger.debug(
+                "Skipping view %s: parquet file not available", view_name
+            )
+            return
         # Use forward slashes for DuckDB compatibility
         path_str = str(path).replace("\\", "/")
 

--- a/src/mtgjson_sdk/models/cards.py
+++ b/src/mtgjson_sdk/models/cards.py
@@ -221,6 +221,10 @@ class CardSet(CardPrintingFull):
         default=None, alias="sourceProducts"
     )
 
+    # Booster simulation metadata (populated by open_pack(), None otherwise)
+    is_foil: bool | None = Field(default=None, alias="isFoil")
+    booster_sheet: str | None = Field(default=None, alias="boosterSheet")
+
 
 class CardDeck(CardPrintingFull):
     """Card in a preconstructed deck, with count and foil/etched flags."""

--- a/src/mtgjson_sdk/queries/prices.py
+++ b/src/mtgjson_sdk/queries/prices.py
@@ -27,6 +27,10 @@ class PriceQuery:
         """Register the all_prices_today parquet view if not already done."""
         self._conn.ensure_views("all_prices_today")
 
+    def _has_prices(self) -> bool:
+        """Check if the price view was successfully registered."""
+        return "all_prices_today" in self._conn._registered_views
+
     def get(self, uuid: str) -> dict | None:
         """Get full price data for a card UUID.
 
@@ -289,6 +293,9 @@ class PriceQuery:
             ``cheapest_number``, ``cheapest_uuid``, ``min_price``.
         """
         self._ensure()
+        if not self._has_prices():
+            return []
+        
         self._conn.ensure_views("cards")
 
         sql = (

--- a/src/mtgjson_sdk/queries/sets.py
+++ b/src/mtgjson_sdk/queries/sets.py
@@ -181,6 +181,8 @@ class SetQuery:
             card_count, and date — or None if no price data exists.
         """
         self._conn.ensure_views("cards", "all_prices_today")
+        if "all_prices_today" not in self._conn._registered_views:
+            return None
 
         sql = """
             SELECT


### PR DESCRIPTION
SDK changes:
- Add is_foil and booster_sheet fields to CardSet model so open_pack() reports whether each card was pulled from a foil sheet.
- Rewrite BoosterSimulator to load config from flat CDN parquet tables (setBoosterSheets, setBoosterSheetCards, etc.) instead of requiring nested booster column from AllPrintings.parquet.
- Pre-fetch all eligible cards on first open_pack() call per set/type, eliminating per-pack DuckDB queries.
- Catch FileNotFoundError in Connection._ensure_view so missing parquet files in offline mode skip gracefully instead of crashing.
- Return empty/None from PriceQuery and SetQuery when price view is unavailable.

Example app:
  Single-file CLI tool that simulates opening booster packs and reports expected value from the booster sheet metadata.
  Outputs per-rarity EV breakdown, top money cards with pull rates, and pack value distribution histogram.